### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A powerful Model Context Protocol server for Keycloak administration, providing a comprehensive set of tools to manage users, realms, roles, and other Keycloak resources through LLM interfaces.
 
+<a href="https://glama.ai/mcp/servers/@Octodet/keycloak-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Octodet/keycloak-mcp/badge" alt="Advanced Keycloak server MCP server" />
+</a>
+
 ## Features
 
 - **User Management**: Create, delete, and list users across realms


### PR DESCRIPTION
This PR adds a badge for the [Advanced Keycloak MCP server](https://glama.ai/mcp/servers/@Octodet/keycloak-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Octodet/keycloak-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Octodet/keycloak-mcp/badge" alt="Advanced Keycloak server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.